### PR TITLE
Add extra volume support so that private CA certificates can be added (rather than ignoring certs)

### DIFF
--- a/charts/docker-registry-browser/templates/deployment.yaml
+++ b/charts/docker-registry-browser/templates/deployment.yaml
@@ -58,6 +58,10 @@ spec:
           volumeMounts:
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
           {{- end }}
+      {{- if .Values.extraVolumes }}
+      volumes:
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/docker-registry-browser/templates/deployment.yaml
+++ b/charts/docker-registry-browser/templates/deployment.yaml
@@ -54,6 +54,10 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/docker-registry-browser/values.yaml
+++ b/charts/docker-registry-browser/values.yaml
@@ -82,3 +82,13 @@ tolerations: []
 affinity: {}
 
 environment: {}
+
+extraVolumes: []
+## Additional volumes to the pod.
+#  - name: cloudfront-pem-secret
+#    secret:
+#      secretName: cloudfront-credentials
+#      items:
+#        - key: cloudfront.pem
+#          path: cloudfront.pem
+#          mode: 511

--- a/charts/docker-registry-browser/values.yaml
+++ b/charts/docker-registry-browser/values.yaml
@@ -83,6 +83,12 @@ affinity: {}
 
 environment: {}
 
+extraVolumeMounts: []
+## Additional volumeMounts to the registry container.
+#  - mountPath: /secret-data
+#    name: cloudfront-pem-secret
+#    readOnly: true
+
 extraVolumes: []
 ## Additional volumes to the pod.
 #  - name: cloudfront-pem-secret


### PR DESCRIPTION
Scenarios like this can be supported:

```yaml
environment:
  ENABLE_DELETE_IMAGES: "true"
  DOCKER_REGISTRY_URL: "https://..."
  BASIC_AUTH_USER: "..."
  BASIC_AUTH_PASSWORD: "..."
  CA_FILE: "/secrets/ca.crt"

extraVolumeMounts:
  - name: ca-certificate
    mountPath: /secrets
    readOnly: true

extraVolumes:
  - name: ca-certificate
    secret:
      secretName: "root-secret"
      items:
        - key: "ca.crt"
          path: "ca.crt"
          mode: 0644
      optional: false
```