### PR TITLE
Feat: be able to specify a nodePort in values when type is NodePort

### DIFF
--- a/charts/docker-registry-browser/templates/service.yaml
+++ b/charts/docker-registry-browser/templates/service.yaml
@@ -11,5 +11,9 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+      {{ if .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{ end }}
+
   selector:
     {{- include "docker-registry-browser.selectorLabels" . | nindent 4 }}

--- a/charts/docker-registry-browser/templates/service.yaml
+++ b/charts/docker-registry-browser/templates/service.yaml
@@ -11,9 +11,9 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-      {{ if .Values.service.nodePort }}
+      {{- if .Values.service.nodePort }}
       nodePort: {{ .Values.service.nodePort }}
-      {{ end }}
+      {{- end }}
 
   selector:
     {{- include "docker-registry-browser.selectorLabels" . | nindent 4 }}

--- a/charts/docker-registry-browser/values.yaml
+++ b/charts/docker-registry-browser/values.yaml
@@ -39,6 +39,7 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 80
+  nodePort:
 
 ingress:
   enabled: false


### PR DESCRIPTION
It would be nice to be able to specify a `nodePort` when defined in `values.yml`.

Without `values.yml`, it generates the following:
```yaml
service:
  type: ClusterIP
  port: 80
```
Whereas with this `values.yml`:
```yaml
---
service:
  type: NodePort
  nodePort: 32001
```
It would generate the following:
```yaml
service:
  type: NodePort
  port: 80
  nodePort: 32001
```
